### PR TITLE
WIP: Update WebAuthn4J to 0.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     </modules>
 
     <properties>
-        <webauthn4j.version>0.8.5.RELEASE</webauthn4j.version>
+        <webauthn4j.version>0.9.0-SNAPSHOT</webauthn4j.version>
         <keycloak.version>4.8.3.Final</keycloak.version>
         <java.version>1.8</java.version>
         <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/webauthn4j-ejb/pom.xml
+++ b/webauthn4j-ejb/pom.xml
@@ -44,4 +44,14 @@
             <artifactId>webauthn4j-core</artifactId>
         </dependency>
     </dependencies>
+    <repositories>
+        <repository>
+            <id>ojo-snapshots</id>
+            <name>OJO Snapshots</name>
+            <url>https://oss.jfrog.org/artifactory/libs-snapshot</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 </project>

--- a/webauthn4j-ejb/src/main/java/org/keycloak/authenticator/RegisterAuthenticator.java
+++ b/webauthn4j-ejb/src/main/java/org/keycloak/authenticator/RegisterAuthenticator.java
@@ -1,9 +1,9 @@
 package org.keycloak.authenticator;
 
-import com.webauthn4j.response.WebAuthnRegistrationContext;
-import com.webauthn4j.response.client.Origin;
-import com.webauthn4j.response.client.challenge.Challenge;
-import com.webauthn4j.response.client.challenge.DefaultChallenge;
+import com.webauthn4j.data.WebAuthnRegistrationContext;
+import com.webauthn4j.data.client.Origin;
+import com.webauthn4j.data.client.challenge.Challenge;
+import com.webauthn4j.data.client.challenge.DefaultChallenge;
 import com.webauthn4j.server.ServerProperty;
 import com.webauthn4j.validator.WebAuthnRegistrationContextValidationResponse;
 import com.webauthn4j.validator.WebAuthnRegistrationContextValidator;

--- a/webauthn4j-ejb/src/main/java/org/keycloak/authenticator/WebAuthn4jAuthenticator.java
+++ b/webauthn4j-ejb/src/main/java/org/keycloak/authenticator/WebAuthn4jAuthenticator.java
@@ -1,10 +1,10 @@
 package org.keycloak.authenticator;
 
 
-import com.webauthn4j.response.WebAuthnAuthenticationContext;
-import com.webauthn4j.response.client.Origin;
-import com.webauthn4j.response.client.challenge.Challenge;
-import com.webauthn4j.response.client.challenge.DefaultChallenge;
+import com.webauthn4j.data.WebAuthnAuthenticationContext;
+import com.webauthn4j.data.client.Origin;
+import com.webauthn4j.data.client.challenge.Challenge;
+import com.webauthn4j.data.client.challenge.DefaultChallenge;
 import com.webauthn4j.server.ServerProperty;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.authentication.Authenticator;

--- a/webauthn4j-ejb/src/main/java/org/keycloak/credential/WebAuthnCredentialModel.java
+++ b/webauthn4j-ejb/src/main/java/org/keycloak/credential/WebAuthnCredentialModel.java
@@ -1,9 +1,9 @@
 package org.keycloak.credential;
 
 
-import com.webauthn4j.response.WebAuthnAuthenticationContext;
-import com.webauthn4j.response.attestation.authenticator.AttestedCredentialData;
-import com.webauthn4j.response.attestation.statement.AttestationStatement;
+import com.webauthn4j.data.WebAuthnAuthenticationContext;
+import com.webauthn4j.data.attestation.authenticator.AttestedCredentialData;
+import com.webauthn4j.data.attestation.statement.AttestationStatement;
 
 public class WebAuthnCredentialModel implements CredentialInput {
 

--- a/webauthn4j-ejb/src/main/java/org/keycloak/endpoint/WebAuthnSettingsProvider.java
+++ b/webauthn4j-ejb/src/main/java/org/keycloak/endpoint/WebAuthnSettingsProvider.java
@@ -1,11 +1,11 @@
 package org.keycloak.endpoint;
 
 import com.webauthn4j.converter.util.JsonConverter;
-import com.webauthn4j.request.AuthenticatorSelectionCriteria;
-import com.webauthn4j.request.PublicKeyCredentialCreationOptions;
-import com.webauthn4j.request.PublicKeyCredentialParameters;
-import com.webauthn4j.request.PublicKeyCredentialType;
-import com.webauthn4j.response.attestation.statement.COSEAlgorithmIdentifier;
+import com.webauthn4j.data.AuthenticatorSelectionCriteria;
+import com.webauthn4j.data.PublicKeyCredentialCreationOptions;
+import com.webauthn4j.data.PublicKeyCredentialParameters;
+import com.webauthn4j.data.PublicKeyCredentialType;
+import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.services.resource.RealmResourceProvider;
 

--- a/webauthn4j-ejb/src/main/java/org/keycloak/models/jpa/AuthenticatorEntity.java
+++ b/webauthn4j-ejb/src/main/java/org/keycloak/models/jpa/AuthenticatorEntity.java
@@ -1,8 +1,8 @@
 package org.keycloak.models.jpa;
 
-import com.webauthn4j.response.attestation.authenticator.AAGUID;
-import com.webauthn4j.response.attestation.authenticator.CredentialPublicKey;
-import com.webauthn4j.response.attestation.statement.AttestationStatement;
+import com.webauthn4j.data.attestation.authenticator.AAGUID;
+import com.webauthn4j.data.attestation.authenticator.CredentialPublicKey;
+import com.webauthn4j.data.attestation.statement.AttestationStatement;
 import org.keycloak.models.jpa.entities.UserEntity;
 import org.keycloak.models.jpa.converter.AAGUIDConverter;
 import org.keycloak.models.jpa.converter.AttestationStatementConverter;

--- a/webauthn4j-ejb/src/main/java/org/keycloak/models/jpa/JpaWebAuthnAuthenticatorStore.java
+++ b/webauthn4j-ejb/src/main/java/org/keycloak/models/jpa/JpaWebAuthnAuthenticatorStore.java
@@ -1,6 +1,6 @@
 package org.keycloak.models.jpa;
 
-import com.webauthn4j.response.attestation.authenticator.AttestedCredentialData;
+import com.webauthn4j.data.attestation.authenticator.AttestedCredentialData;
 import org.keycloak.connections.jpa.JpaConnectionProvider;
 import org.keycloak.credential.WebAuthnCredentialModel;
 import org.keycloak.models.KeycloakSession;

--- a/webauthn4j-ejb/src/main/java/org/keycloak/models/jpa/converter/AAGUIDConverter.java
+++ b/webauthn4j-ejb/src/main/java/org/keycloak/models/jpa/converter/AAGUIDConverter.java
@@ -1,6 +1,6 @@
 package org.keycloak.models.jpa.converter;
 
-import com.webauthn4j.response.attestation.authenticator.AAGUID;
+import com.webauthn4j.data.attestation.authenticator.AAGUID;
 
 import javax.persistence.AttributeConverter;
 

--- a/webauthn4j-ejb/src/main/java/org/keycloak/models/jpa/converter/AttestationStatementConverter.java
+++ b/webauthn4j-ejb/src/main/java/org/keycloak/models/jpa/converter/AttestationStatementConverter.java
@@ -1,7 +1,7 @@
 package org.keycloak.models.jpa.converter;
 
 import com.webauthn4j.converter.util.JsonConverter;
-import com.webauthn4j.response.attestation.statement.AttestationStatement;
+import com.webauthn4j.data.attestation.statement.AttestationStatement;
 
 import javax.persistence.AttributeConverter;
 

--- a/webauthn4j-ejb/src/main/java/org/keycloak/models/jpa/converter/CredentialPublicKeyConverter.java
+++ b/webauthn4j-ejb/src/main/java/org/keycloak/models/jpa/converter/CredentialPublicKeyConverter.java
@@ -1,7 +1,7 @@
 package org.keycloak.models.jpa.converter;
 
 import com.webauthn4j.converter.util.JsonConverter;
-import com.webauthn4j.response.attestation.authenticator.CredentialPublicKey;
+import com.webauthn4j.data.attestation.authenticator.CredentialPublicKey;
 
 import javax.persistence.AttributeConverter;
 


### PR DESCRIPTION
Update WebAuthn4J to 0.9.0
As of 2019-03-16, it is not released. snapshot is used for the time being.